### PR TITLE
feat: 支持按份额和交易时段记录基金转换

### DIFF
--- a/app/components/FundConvertModal.jsx
+++ b/app/components/FundConvertModal.jsx
@@ -6,29 +6,28 @@ import { CloseIcon } from './Icons';
 import { Info } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { DatePicker, NumericInput } from './Common';
-import { fetchSmartFundNetValueBackward } from '../api/fund';
+import { fetchSmartFundNetValue } from '../api/fund';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { formatMoney } from '@/lib/utils';
 
-const format2 = (v) => {
+const formatShare = (v) => {
   const n = Number(v);
   if (!Number.isFinite(n)) return '';
-  return n.toFixed(2);
+  return Number(n.toFixed(6)).toString();
 };
 
 export default function FundConvertModal({
   fund,
-  maxOutAmount = 0,
-  allFunds = [],
+  maxOutShare = 0,
   nestedModalOpen = false,
   onClose,
   onPickInFund,
   onConfirm
 }) {
-  const [outAmount, setOutAmount] = useState('');
-  const [inAmount, setInAmount] = useState('');
+  const [outShare, setOutShare] = useState('');
   const [inFund, setInFund] = useState(null);
-  const [confirmDate, setConfirmDate] = useState(() => dayjs().format('YYYY-MM-DD'));
+  const [applyDate, setApplyDate] = useState(() => dayjs().format('YYYY-MM-DD'));
+  const [isAfter3pm, setIsAfter3pm] = useState(() => dayjs().hour() >= 15);
   const [outNetValue, setOutNetValue] = useState(null);
   const [outNetValueDate, setOutNetValueDate] = useState(null);
   const [inNetValue, setInNetValue] = useState(null);
@@ -41,10 +40,10 @@ export default function FundConvertModal({
 
   useEffect(() => {
     // 每次打开/切换 fund 时重置表单（避免上一次残留）
-    setOutAmount('');
-    setInAmount('');
+    setOutShare('');
     setInFund(null);
-    setConfirmDate(dayjs().format('YYYY-MM-DD'));
+    setApplyDate(dayjs().format('YYYY-MM-DD'));
+    setIsAfter3pm(dayjs().hour() >= 15);
     setOutNetValue(null);
     setOutNetValueDate(null);
     setInNetValue(null);
@@ -55,16 +54,14 @@ export default function FundConvertModal({
   }, [fund?.code]);
 
   const maxOut = useMemo(() => {
-    const n = Number(maxOutAmount);
-    return Number.isFinite(n) && n > 0 ? Number(n.toFixed(2)) : 0;
-  }, [maxOutAmount]);
+    const n = Number(maxOutShare);
+    return Number.isFinite(n) && n > 0 ? Number(n.toFixed(6)) : 0;
+  }, [maxOutShare]);
 
-  const outAmt = useMemo(() => Number.parseFloat(outAmount), [outAmount]);
-  const inAmt = useMemo(() => Number.parseFloat(inAmount), [inAmount]);
+  const outShareValue = useMemo(() => Number.parseFloat(outShare), [outShare]);
 
-  const outValid = Number.isFinite(outAmt) && outAmt > 0 && outAmt <= maxOut;
-  const inValid = Number.isFinite(inAmt) && inAmt > 0;
-  const canSubmit = !!fund?.code && !!inFund?.code && outValid && inValid && !!confirmDate;
+  const outValid = Number.isFinite(outShareValue) && outShareValue > 0 && outShareValue <= maxOut;
+  const canSubmit = !!fund?.code && !!inFund?.code && outValid && !!applyDate;
 
   useEffect(() => {
     if (nestedModalOpen) {
@@ -81,15 +78,15 @@ export default function FundConvertModal({
     if (!open) onClose?.();
   };
 
-  const hintMax = maxOut > 0 ? `最多可转出 ${formatMoney(maxOut)}` : '暂无可转出金额';
-  const refStartDate = useMemo(() => {
-    const d = dayjs(confirmDate, 'YYYY-MM-DD', true);
+  const hintMax = maxOut > 0 ? `最多可转出 ${maxOut} 份` : '暂无可转出份额';
+  const navQueryDate = useMemo(() => {
+    const d = dayjs(applyDate, 'YYYY-MM-DD', true);
     if (!d.isValid()) return null;
-    return d.subtract(1, 'day').format('YYYY-MM-DD');
-  }, [confirmDate]);
+    return (isAfter3pm ? d.add(1, 'day') : d).format('YYYY-MM-DD');
+  }, [applyDate, isAfter3pm]);
 
   useEffect(() => {
-    if (!fund?.code || !refStartDate) return;
+    if (!fund?.code || !navQueryDate) return;
 
     const getNetValues = async () => {
       setLoadingNetValue(true);
@@ -102,8 +99,8 @@ export default function FundConvertModal({
 
       try {
         const tasks = [
-          fetchSmartFundNetValueBackward(fund.code, refStartDate),
-          inFund?.code ? fetchSmartFundNetValueBackward(inFund.code, refStartDate) : Promise.resolve(null)
+          fetchSmartFundNetValue(fund.code, navQueryDate),
+          inFund?.code ? fetchSmartFundNetValue(inFund.code, navQueryDate) : Promise.resolve(null)
         ];
         const [outRes, inRes] = await Promise.all(tasks);
         if (outRes && outRes.value) {
@@ -130,7 +127,10 @@ export default function FundConvertModal({
 
     const timer = setTimeout(getNetValues, 500);
     return () => clearTimeout(timer);
-  }, [fund?.code, inFund?.code, refStartDate]);
+  }, [fund?.code, inFund?.code, navQueryDate]);
+
+  const estimatedInAmount = outValid && outNetValue ? outShareValue * Number(outNetValue) : null;
+  const estimatedInShare = estimatedInAmount && inNetValue ? estimatedInAmount / Number(inNetValue) : null;
 
   return (
     <Dialog open onOpenChange={handleOpenChange}>
@@ -167,7 +167,7 @@ export default function FundConvertModal({
 
         <Alert style={{ marginBottom: 16, flexShrink: 0 }} variant="info">
           <Info className="h-4 w-4" />
-          <AlertDescription>需要基金转换完成后再添加</AlertDescription>
+          <AlertDescription>提交后将等待两只基金的确认净值，并自动完成转出与转入</AlertDescription>
         </Alert>
 
         <div className="scrollbar-y-styled" style={{ overflowY: 'auto', paddingRight: 4, flex: 1 }}>
@@ -202,15 +202,15 @@ export default function FundConvertModal({
 
           <div className="form-group" style={{ marginBottom: 16 }}>
             <label className="muted" style={{ display: 'block', marginBottom: 8, fontSize: '14px' }}>
-              转出金额 <span style={{ color: 'var(--danger)' }}>*</span>
+              转出份额 <span style={{ color: 'var(--danger)' }}>*</span>
             </label>
             <div
               style={{
-                border: !outAmount || !outValid ? '1px solid var(--danger)' : '1px solid var(--border)',
+                border: !outShare || !outValid ? '1px solid var(--danger)' : '1px solid var(--border)',
                 borderRadius: 12
               }}
             >
-              <NumericInput value={outAmount} onChange={setOutAmount} step={100} min={0} placeholder="请输入转出金额" />
+              <NumericInput value={outShare} onChange={setOutShare} step={1} min={0} placeholder="请输入转出份额" />
             </div>
             {maxOut > 0 && (
               <div className="row" style={{ gap: 8, marginTop: 8 }}>
@@ -224,7 +224,7 @@ export default function FundConvertModal({
                     key={opt.label}
                     type="button"
                     className="trade-amount-btn"
-                    onClick={() => setOutAmount(format2(maxOut * opt.value))}
+                    onClick={() => setOutShare(formatShare(maxOut * opt.value))}
                   >
                     {opt.label}
                   </button>
@@ -268,25 +268,27 @@ export default function FundConvertModal({
             </button>
           </div>
 
-          <div className="form-group" style={{ marginBottom: 16 }}>
-            <label className="muted" style={{ display: 'block', marginBottom: 8, fontSize: '14px' }}>
-              转入金额 <span style={{ color: 'var(--danger)' }}>*</span>
-            </label>
-            <div
-              style={{
-                border: !inAmount || !inValid ? '1px solid var(--danger)' : '1px solid var(--border)',
-                borderRadius: 12
-              }}
-            >
-              <NumericInput value={inAmount} onChange={setInAmount} step={100} min={0} placeholder="请输入转入金额" />
-            </div>
-          </div>
-
           <div className="form-group" style={{ marginBottom: 8 }}>
             <label className="muted" style={{ display: 'block', marginBottom: 8, fontSize: '14px' }}>
-              确认转换日期
+              转换申请日期
             </label>
-            <DatePicker value={confirmDate} onChange={setConfirmDate} />
+            <DatePicker value={applyDate} onChange={setApplyDate} />
+            <div className="trade-time-slot row" style={{ gap: 8, marginTop: 10 }}>
+              <button
+                type="button"
+                className={!isAfter3pm ? 'trade-time-btn active' : 'trade-time-btn'}
+                onClick={() => setIsAfter3pm(false)}
+              >
+                15:00前
+              </button>
+              <button
+                type="button"
+                className={isAfter3pm ? 'trade-time-btn active' : 'trade-time-btn'}
+                onClick={() => setIsAfter3pm(true)}
+              >
+                15:00后
+              </button>
+            </div>
             {loadingNetValue && (
               <div className="muted" style={{ fontSize: '12px', marginTop: 4 }}>
                 正在获取净值...
@@ -312,6 +314,21 @@ export default function FundConvertModal({
                 参考净值(转入): {inNetValue} ({inNetValueDate})
               </div>
             )}
+            {estimatedInAmount && estimatedInShare && !loadingNetValue && (
+              <div className="trade-confirm-card" style={{ marginTop: 12, fontSize: 12 }}>
+                <div className="row" style={{ justifyContent: 'space-between', marginBottom: 6 }}>
+                  <span className="muted">预计转入金额</span>
+                  <span>{formatMoney(estimatedInAmount)}</span>
+                </div>
+                <div className="row" style={{ justifyContent: 'space-between' }}>
+                  <span className="muted">预计转入份额</span>
+                  <span>{estimatedInShare.toFixed(6)} 份</span>
+                </div>
+              </div>
+            )}
+            <div className="muted" style={{ marginTop: 8, fontSize: 12 }}>
+              * 按转换费为 0 估算，最终结果以基金公司确认为准
+            </div>
           </div>
         </div>
 
@@ -329,11 +346,11 @@ export default function FundConvertModal({
                 onConfirm?.({
                   outFundCode: fund.code,
                   outFundName: fund.name,
-                  outAmount: outAmt,
+                  outShare: outShareValue,
                   inFundCode: inFund.code,
                   inFundName: inFund.name,
-                  inAmount: inAmt,
-                  date: confirmDate
+                  date: applyDate,
+                  isAfter3pm
                 });
               }}
               style={{ flex: 1, opacity: canSubmit ? 1 : 0.6 }}

--- a/app/components/ModalsLayer.jsx
+++ b/app/components/ModalsLayer.jsx
@@ -77,6 +77,15 @@ export default function ModalsLayer({ callbacksRef }) {
 function ModalsLayerContent({ callbacksRef }) {
   const cb = callbacksRef;
 
+  const revokePendingTrade = (id) => {
+    cb.current.setPendingTrades?.((prev) => {
+      const target = (prev || []).find((trade) => trade.id === id);
+      if (!target?.conversionId) return (prev || []).filter((trade) => trade.id !== id);
+      return (prev || []).filter((trade) => trade.conversionId !== target.conversionId);
+    });
+    cb.current.showToast?.('已撤销待处理交易', 'success');
+  };
+
   // ========== Modal 开关状态订阅 ==========
   const settingsOpen = useModalStore((s) => s.settingsOpen);
   const feedbackOpen = useModalStore((s) => s.feedbackOpen);
@@ -407,11 +416,7 @@ function ModalsLayerContent({ callbacksRef }) {
                   : t.groupId === cb.current.getScopedGroupId?.(tradeModal.groupId))
             )}
             onDeletePending={(id) => {
-              cb.current.setPendingTrades?.((prev) => {
-                const next = prev.filter((t) => t.id !== id);
-                return next;
-              });
-              cb.current.showToast?.('已撤销待处理交易', 'success');
+              revokePendingTrade(id);
             }}
           />
         )}
@@ -487,17 +492,23 @@ function ModalsLayerContent({ callbacksRef }) {
         {convertModal.open && (
           <FundConvertModal
             fund={convertModal.fund}
-            allFunds={cb.current.funds}
             nestedModalOpen={selectFundSingleModal.open}
-            maxOutAmount={(() => {
+            maxOutShare={(() => {
               const f = convertModal.fund;
               const code = f?.code;
               if (!code) return 0;
               const holding = cb.current.getScopedHolding?.(code, convertModal.groupId);
               const share = Number(holding?.share) || 0;
-              const nav = Number(f?.dwjz) || Number(f?.gsz) || 0;
-              if (!share || !nav) return 0;
-              return share * nav;
+              const tradeGid = cb.current.getScopedGroupId?.(convertModal.groupId);
+              const frozenShare = (cb.current.pendingTrades || [])
+                .filter(
+                  (trade) =>
+                    trade.fundCode === code &&
+                    trade.type === 'sell' &&
+                    (tradeGid ? trade.groupId === tradeGid : !trade.groupId)
+                )
+                .reduce((total, trade) => total + (Number(trade.share) || 0), 0);
+              return Math.max(0, share - frozenShare);
             })()}
             onClose={() => setConvertModal({ open: false, fund: null })}
             onPickInFund={({ excludeCodes, initialSelectedCode }) => {
@@ -513,22 +524,25 @@ function ModalsLayerContent({ callbacksRef }) {
             onConfirm={(payload) => {
               const tradeGid = cb.current.getScopedGroupId?.(convertModal.groupId);
               const nowTs = Date.now();
+              const conversionId = uuidv4();
 
               const outPending = {
                 id: uuidv4(),
                 fundCode: payload.outFundCode,
                 fundName: payload.outFundName,
                 type: 'sell',
-                share: null,
-                amount: payload.outAmount,
+                share: payload.outShare,
+                amount: null,
                 feeRate: 0,
                 feeMode: 'none',
                 feeValue: 0,
                 date: payload.date,
-                navOffsetDays: -1,
-                netValueSearch: 'backward',
-                isAfter3pm: false,
+                isAfter3pm: payload.isAfter3pm,
                 isDca: false,
+                conversionId,
+                conversionRole: 'out',
+                conversionPeerFundCode: payload.inFundCode,
+                conversionPeerFundName: payload.inFundName,
                 timestamp: nowTs,
                 ...(tradeGid ? { groupId: tradeGid } : {})
               };
@@ -539,15 +553,18 @@ function ModalsLayerContent({ callbacksRef }) {
                 fundName: payload.inFundName,
                 type: 'buy',
                 share: null,
-                amount: payload.inAmount,
+                amount: null,
                 feeRate: 0,
                 feeMode: 'none',
                 feeValue: 0,
                 date: payload.date,
-                navOffsetDays: -1,
-                netValueSearch: 'backward',
-                isAfter3pm: false,
+                isAfter3pm: payload.isAfter3pm,
                 isDca: false,
+                conversionId,
+                conversionRole: 'in',
+                conversionOutShare: payload.outShare,
+                conversionPeerFundCode: payload.outFundCode,
+                conversionPeerFundName: payload.outFundName,
                 timestamp: nowTs + 1,
                 ...(tradeGid ? { groupId: tradeGid } : {})
               };
@@ -683,11 +700,7 @@ function ModalsLayerContent({ callbacksRef }) {
               cb.current.handleMergeAllGroupTransactionsToCurrent?.(historyModal.fund?.code, historyModal.groupId)
             }
             onDeletePending={(id) => {
-              cb.current.setPendingTrades?.((prev) => {
-                const next = prev.filter((t) => t.id !== id);
-                return next;
-              });
-              cb.current.showToast?.('已撤销待处理交易', 'success');
+              revokePendingTrade(id);
             }}
           />
         )}

--- a/app/components/PendingTradesModal.jsx
+++ b/app/components/PendingTradesModal.jsx
@@ -44,7 +44,13 @@ export default function PendingTradesModal({ open, trades = [], onClose, onRevok
                       color: trade.type === 'buy' ? 'var(--danger)' : 'var(--success)'
                     }}
                   >
-                    {trade.type === 'buy' ? '买入' : '卖出'}
+                    {trade.conversionRole === 'in'
+                      ? '转换转入'
+                      : trade.conversionRole === 'out'
+                        ? '转换转出'
+                        : trade.type === 'buy'
+                          ? '买入'
+                          : '卖出'}
                   </span>
                   <span className="muted" style={{ fontSize: '12px' }}>
                     {trade.date} {trade.isAfter3pm ? '(15:00后)' : ''}
@@ -52,7 +58,13 @@ export default function PendingTradesModal({ open, trades = [], onClose, onRevok
                 </div>
                 <div className="row" style={{ justifyContent: 'space-between', fontSize: '12px' }}>
                   <span className="muted">份额/金额</span>
-                  <span>{trade.share ? `${trade.share} 份` : `${trade.amount}`}</span>
+                  <span>
+                    {trade.share
+                      ? `${trade.share} 份`
+                      : trade.conversionRole === 'in'
+                        ? '按转出确认金额计算'
+                        : `${trade.amount}`}
+                  </span>
                 </div>
                 <div className="row" style={{ justifyContent: 'space-between', fontSize: '12px', marginTop: 4 }}>
                   <span className="muted">状态</span>

--- a/app/components/TransactionHistoryModal.jsx
+++ b/app/components/TransactionHistoryModal.jsx
@@ -172,7 +172,13 @@ export default function TransactionHistoryModal({
                           color: item.type === 'buy' ? 'var(--primary)' : 'var(--danger)'
                         }}
                       >
-                        {item.type === 'buy' ? '买入' : '卖出'}
+                        {item.conversionRole === 'in'
+                          ? '转换转入'
+                          : item.conversionRole === 'out'
+                            ? '转换转出'
+                            : item.type === 'buy'
+                              ? '买入'
+                              : '卖出'}
                       </span>
                       {item.type === 'buy' && item.isDca && <span className="tx-history-dca-badge">定投</span>}
                     </div>
@@ -182,7 +188,13 @@ export default function TransactionHistoryModal({
                   </div>
                   <div className="row" style={{ justifyContent: 'space-between', fontSize: '12px' }}>
                     <span className="muted">份额/金额</span>
-                    <span>{item.share ? `${Number(item.share).toFixed(2)} 份` : `${formatMoney(item.amount)}`}</span>
+                    <span>
+                      {item.share
+                        ? `${Number(item.share).toFixed(2)} 份`
+                        : item.conversionRole === 'in'
+                          ? '按转出确认金额计算'
+                          : `${formatMoney(item.amount)}`}
+                    </span>
                   </div>
                   <div className="row" style={{ justifyContent: 'space-between', fontSize: '12px', marginTop: 8 }}>
                     <span className="tx-history-pending-status">等待净值更新...</span>
@@ -223,7 +235,13 @@ export default function TransactionHistoryModal({
                           color: item.type === 'buy' ? 'var(--primary)' : 'var(--danger)'
                         }}
                       >
-                        {item.type === 'buy' ? '买入' : '卖出'}
+                        {item.conversionRole === 'in'
+                          ? '转换转入'
+                          : item.conversionRole === 'out'
+                            ? '转换转出'
+                            : item.type === 'buy'
+                              ? '买入'
+                              : '卖出'}
                       </span>
                       {item.type === 'buy' && item.isDca && <span className="tx-history-dca-badge">定投</span>}
                     </div>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1621,6 +1621,15 @@ export default function HomePage() {
       const newTransactions = [];
 
       const handledIds = new Set();
+      const conversionPairs = new Map();
+      currentPending.forEach((trade) => {
+        if (!trade?.conversionId) return;
+        const pair = conversionPairs.get(trade.conversionId) || {};
+        if (trade.conversionRole === 'out') pair.out = trade;
+        if (trade.conversionRole === 'in') pair.in = trade;
+        conversionPairs.set(trade.conversionId, pair);
+      });
+
       const readCurrent = (fundCode, tradeGid) => {
         if (!tradeGid) {
           return tempHoldings[fundCode] || { share: 0, cost: 0 };
@@ -1638,25 +1647,108 @@ export default function HomePage() {
         }
       };
 
-      for (const trade of currentPending) {
-        if (trade?.id && handledIds.has(trade.id)) continue;
-        if (trade?.id) handledIds.add(trade.id);
-
-        const tradeGid = trade.groupId || null;
+      const fetchPendingNetValue = async (trade) => {
         let queryDate = trade.date;
         if (trade.isAfter3pm) {
           queryDate = toTz(trade.date).add(1, 'day').format('YYYY-MM-DD');
         }
 
-        // 尝试获取智能净值
         const navOffsetDays = Number(trade.navOffsetDays);
         if (Number.isFinite(navOffsetDays) && navOffsetDays) {
           queryDate = toTz(queryDate).add(navOffsetDays, 'day').format('YYYY-MM-DD');
         }
-        const result =
-          trade.netValueSearch === 'backward'
-            ? await fetchSmartFundNetValueBackward(trade.fundCode, queryDate)
-            : await fetchSmartFundNetValue(trade.fundCode, queryDate);
+
+        return trade.netValueSearch === 'backward'
+          ? fetchSmartFundNetValueBackward(trade.fundCode, queryDate)
+          : fetchSmartFundNetValue(trade.fundCode, queryDate);
+      };
+
+      for (const trade of currentPending) {
+        if (trade?.id && handledIds.has(trade.id)) continue;
+
+        if (trade?.conversionId) {
+          const pair = conversionPairs.get(trade.conversionId);
+          if (!pair?.out || !pair?.in) continue;
+
+          handledIds.add(pair.out.id);
+          handledIds.add(pair.in.id);
+
+          const [outResult, inResult] = await Promise.all([
+            fetchPendingNetValue(pair.out),
+            fetchPendingNetValue(pair.in)
+          ]);
+          if (!outResult?.value || !inResult?.value) continue;
+
+          const tradeGid = pair.out.groupId || null;
+          const outCurrent = readCurrent(pair.out.fundCode, tradeGid);
+          const inCurrent = readCurrent(pair.in.fundCode, tradeGid);
+          const outShare = Number(pair.out.share) || 0;
+          if (outShare <= 0 || outShare > outCurrent.share) continue;
+
+          const transferAmount = outShare * Number(outResult.value);
+          const inShare = transferAmount / Number(inResult.value);
+          const outNewShare = Math.max(0, outCurrent.share - outShare);
+          const inNewShare = inCurrent.share + inShare;
+          const inNewCost = (inCurrent.cost * inCurrent.share + transferAmount) / inNewShare;
+
+          writeCurrent(pair.out.fundCode, tradeGid, outNewShare, outNewShare === 0 ? 0 : outCurrent.cost, {
+            ...(outCurrent.firstPurchaseDate ? { firstPurchaseDate: outCurrent.firstPurchaseDate } : {})
+          });
+          writeCurrent(pair.in.fundCode, tradeGid, inNewShare, inNewCost, {
+            ...(inCurrent.firstPurchaseDate
+              ? { firstPurchaseDate: inCurrent.firstPurchaseDate }
+              : { firstPurchaseDate: inResult.date })
+          });
+
+          stateChanged = true;
+          processedIds.add(pair.out.id);
+          processedIds.add(pair.in.id);
+
+          newTransactions.push(
+            {
+              id: pair.out.id,
+              fundCode: pair.out.fundCode,
+              type: 'sell',
+              share: outShare,
+              amount: transferAmount,
+              price: outResult.value,
+              date: outResult.date,
+              isAfter3pm: pair.out.isAfter3pm,
+              isDca: false,
+              isConversion: true,
+              conversionId: trade.conversionId,
+              conversionRole: 'out',
+              conversionPeerFundCode: pair.in.fundCode,
+              conversionPeerFundName: pair.in.fundName,
+              timestamp: pair.out.timestamp || Date.now(),
+              ...(tradeGid ? { groupId: tradeGid } : {})
+            },
+            {
+              id: pair.in.id,
+              fundCode: pair.in.fundCode,
+              type: 'buy',
+              share: inShare,
+              amount: transferAmount,
+              price: inResult.value,
+              date: inResult.date,
+              isAfter3pm: pair.in.isAfter3pm,
+              isDca: false,
+              isConversion: true,
+              conversionId: trade.conversionId,
+              conversionRole: 'in',
+              conversionPeerFundCode: pair.out.fundCode,
+              conversionPeerFundName: pair.out.fundName,
+              timestamp: pair.in.timestamp || Date.now(),
+              ...(tradeGid ? { groupId: tradeGid } : {})
+            }
+          );
+          continue;
+        }
+
+        if (trade?.id) handledIds.add(trade.id);
+
+        const tradeGid = trade.groupId || null;
+        const result = await fetchPendingNetValue(trade);
 
         if (result && result.value > 0) {
           // 成功获取，执行交易
@@ -1733,7 +1825,16 @@ export default function HomePage() {
               date: tx.date,
               isAfter3pm: tx.isAfter3pm,
               isDca: tx.isDca,
-              timestamp: tx.timestamp
+              timestamp: tx.timestamp,
+              ...(tx.isConversion
+                ? {
+                    isConversion: true,
+                    conversionId: tx.conversionId,
+                    conversionRole: tx.conversionRole,
+                    conversionPeerFundCode: tx.conversionPeerFundCode,
+                    conversionPeerFundName: tx.conversionPeerFundName
+                  }
+                : {})
             };
             if (tx.groupId) row.groupId = tx.groupId;
             nextTransactions[tx.fundCode] = [row, ...current].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));

--- a/doc/localStorage 数据结构.md
+++ b/doc/localStorage 数据结构.md
@@ -322,7 +322,12 @@
     isAfter3pm: boolean, // 是否下午3点后
     isDca: boolean,      // 是否为定投交易
     timestamp: number,   // 时间戳
-    groupId?: string     // 可选；存在时表示作用于该分组的 groupHoldings；缺省表示全局 holdings
+    groupId?: string,    // 可选；存在时表示作用于该分组的 groupHoldings；缺省表示全局 holdings
+    conversionId?: string, // 可选；基金转换的成对记录 ID
+    conversionRole?: 'out' | 'in', // 可选；转换转出/转入方向
+    conversionOutShare?: number, // 可选；转入记录关联的转出份额
+    conversionPeerFundCode?: string, // 可选；转换对手基金代码
+    conversionPeerFundName?: string  // 可选；转换对手基金名称
   }
 ]
 ```
@@ -331,6 +336,7 @@
 
 - 净值未更新时暂存交易
 - 净值更新后自动处理待处理交易
+- 基金转换的转出、转入记录按 `conversionId` 成对原子处理；两边净值均确认后才同时更新持仓
 - 导入/导出配置时包含
 
 ---
@@ -566,7 +572,12 @@ groupId; // 分组ID，如 'group_xxx'
       isDca: boolean,        // 是否为定投交易
       isHistoryOnly: boolean, // 是否仅历史记录（不参与持仓计算）
       timestamp: number,      // 时间戳
-      groupId?: string        // 可选；存在时表示该笔记录属于某分组子账本；缺省表示全局
+      groupId?: string,       // 可选；存在时表示该笔记录属于某分组子账本；缺省表示全局
+      isConversion?: boolean, // 是否为基金转换记录
+      conversionId?: string, // 可选；基金转换的成对记录 ID
+      conversionRole?: 'out' | 'in', // 可选；转换转出/转入方向
+      conversionPeerFundCode?: string, // 可选；转换对手基金代码
+      conversionPeerFundName?: string  // 可选；转换对手基金名称
     }
   ],
   "110022": [


### PR DESCRIPTION
## 背景

现有基金转换功能需要等待平台转换完成后，再手工填写转出金额、转入金额和确认日期。

实际使用时，用户通常在申请转换时只知道：

- 转出基金
- 转出份额
- 转入基金
- 申请日期
- 15:00 前或 15:00 后

双方确认净值和最终转入份额需要等待基金公司后续确认。原有实现还会从选择日期的前一天向前查询净值，因此当天提交转换时会显示前一交易日净值。

## 改动内容

- 转换输入由“转出金额”改为“转出份额”
- 支持 `1/4`、`1/3`、`1/2`、全部份额快捷选择
- 增加申请日期及 `15:00 前/后` 选择
- 15:00 前从申请日开始查询确认净值
- 15:00 后从下一交易日开始查询确认净值
- 不再要求手工输入转入金额
- 自动计算：
  - 转入金额 = 转出份额 × 转出确认净值
  - 转入份额 = 转入金额 ÷ 转入确认净值
- 转出与转入记录通过 `conversionId` 关联
- 只有两只基金的净值都取得后，才原子更新双方持仓
- 任意一边净值未取得时，整组转换继续保留在待处理队列
- 撤销任意一侧待处理记录时，成对撤销整组转换
- 交易记录区分“转换转出”和“转换转入”
- 扣除已有待处理卖出所冻结的份额
- 更新 localStorage 数据结构文档

## 计算说明

当前与原功能保持一致，转换费暂按 0 估算：


转入金额 = 转出份额 × 转出基金确认净值
转入份额 = 转入金额 ÷ 转入基金确认净值

实际结果仍以基金公司确认数据为准。

## 手工验证

- [x] 可以按份额提交转换
- [x] `1/2` 等快捷按钮正确计算份额
- [x] 15:00 前使用申请日作为净值查询起点
- [x] 15:00 后等待下一交易日净值
- [x] 只有一只基金取得净值时，双方持仓均不更新
- [x] 两只基金都取得净值后，同时完成转出和转入
- [x] 撤销转换任意一侧时，整组待处理记录一起撤销
- [x] 刷新或重新打开页面后，待处理转换仍然存在
- [x] `npm run build` 通过

## 截图
### 转换申请
<img width="1506" height="1948" alt="1" src="https://github.com/user-attachments/assets/f3100006-ac63-450a-8ad1-626ff2975eac" />
<img width="1676" height="1916" alt="2" src="https://github.com/user-attachments/assets/cf040479-f427-4fdb-956d-837616b5bfd7" />

### 待处理状态 + 转换完成结果
<img width="1636" height="1580" alt="3" src="https://github.com/user-attachments/assets/c92c394b-1dde-419c-bfca-ff951a175b6f" />
<img width="1466" height="1628" alt="4" src="https://github.com/user-attachments/assets/86ba1beb-5a9d-4cab-8c1f-ca0bea328a9b" />

### 构建验证
<img width="2402" height="712" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/8770301c-1d67-4b52-b39e-b6dc55096b10" />